### PR TITLE
First level of transactions with blockscout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# hashtracker
+# HashTracker
+
+
+## Local environment
+
+### Backend
+1. Install Golang
+2. Run the project
+
+```go
+go run cmd/* 
+```
+
+### Endpoints
+
+```bash
+curl localhost:8080/transactions/0x8611C17eA68caE77762AdF6446a00f5a71dd7784?level=1
+```
+The following is the expected result
+
+```
+{
+  "transactions": [
+    {
+      "hash": "0x6637a2ab8da7405f1b72dfc325ae80abea0f31149d8bcabf259e402d6a1a2e3e",
+      "from": "0x8611C17eA68caE77762AdF6446a00f5a71dd7784",
+      "to": "0x7cCD87331574Fe39140697962555848236C75DFA",
+      "value": "10000000000000000",
+      "timestamp": "2024-11-14T06:10:23Z"
+    },
+    {
+      "hash": "0x396c3a2b3a63efa6ff81b2b268068a405bc4b159bd0c5946ca07880589e5058a",
+      "from": "0x28C6c06298d514Db089934071355E5743bf21d60",
+      "to": "0x8611C17eA68caE77762AdF6446a00f5a71dd7784",
+      "value": "13009150000000000",
+      "timestamp": "2024-11-14T06:08:23Z"
+    }
+  ]
+}
+```

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -1,16 +1,24 @@
 package app
 
 import (
-	"github.com/labstack/echo/v4"
 	"hashtracker/internal/controller/http"
+	"hashtracker/internal/usecases"
+	"hashtracker/internal/usecases/repo/blockscout"
 	server "hashtracker/pkg/httpserver"
+
+	"github.com/labstack/echo/v4"
 )
 
 func Run() {
-	controller := http.NewHealthController()
+	healthController := http.NewHealthController()
+	txRepo := blockscout.NewTransactionRepository()
+	scannerUseCase := usecases.NewScanner(txRepo)
+	scannerController := http.NewScannerController(scannerUseCase)
+
 	s := echo.New()
 	router := http.NewRouter(s)
-	router.AddGet("/health", controller.Health)
+	router.AddGet("/health", healthController.Health)
+	router.AddGet("/transactions/:address", scannerController.GetTransactions)
 	router.List()
 
 	httpServer := server.New(s, server.Port("8080"))

--- a/backend/internal/controller/http/health.go
+++ b/backend/internal/controller/http/health.go
@@ -1,8 +1,9 @@
 package http
 
 import (
-	"github.com/labstack/echo/v4"
 	"net/http"
+
+	"github.com/labstack/echo/v4"
 )
 
 type HealthController struct{}

--- a/backend/internal/controller/http/router.go
+++ b/backend/internal/controller/http/router.go
@@ -3,9 +3,10 @@ package http
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
-	"net/http"
 )
 
 type Router struct {

--- a/backend/internal/controller/http/scanner.go
+++ b/backend/internal/controller/http/scanner.go
@@ -1,0 +1,34 @@
+package http
+
+import (
+	"context"
+	"hashtracker/internal/entities"
+	"hashtracker/internal/usecases"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+type ScannerController struct {
+	uc usecases.ScannerUseCase
+}
+
+func NewScannerController(uc usecases.ScannerUseCase) *ScannerController {
+	return &ScannerController{
+		uc: uc,
+	}
+}
+
+func (s *ScannerController) GetTransactions(c echo.Context) error {
+	r, err := entities.NewTransactionRequest(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+
+	root, err := s.uc.GetTransactions(context.Background(), r.Address, r.Level)
+	if err != nil {
+		panic(err)
+	}
+
+	return c.JSON(http.StatusOK, root)
+}

--- a/backend/internal/entities/request.go
+++ b/backend/internal/entities/request.go
@@ -1,0 +1,27 @@
+package entities
+
+import (
+	"strconv"
+
+	"github.com/labstack/echo/v4"
+)
+
+type TransactionRequest struct {
+	Address string
+	Level   int
+}
+
+func NewTransactionRequest(c echo.Context) (*TransactionRequest, error) {
+	address := c.Param("address")
+	level := c.QueryParam("level")
+
+	levelInt, err := strconv.ParseInt(level, 10, 32)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TransactionRequest{
+		Address: address,
+		Level:   int(levelInt),
+	}, nil
+}

--- a/backend/internal/entities/transaction.go
+++ b/backend/internal/entities/transaction.go
@@ -1,0 +1,37 @@
+package entities
+
+import (
+	"fmt"
+	"time"
+)
+
+type Transaction struct {
+	Hash      string    `json:"hash"`
+	From      string    `json:"from"`
+	To        string    `json:"to"`
+	Value     string    `json:"value"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+func (t Transaction) String() string {
+	return fmt.Sprintf("[from: %s, to: %s, value: %s timestamp:%s]",
+		t.From, t.To, t.Value, t.Timestamp)
+}
+
+type TransactionList struct {
+	List []*Transaction `json:"transactions"`
+}
+
+func NewTransactionList(l []*Transaction) *TransactionList {
+	return &TransactionList{
+		List: l,
+	}
+}
+
+func (l *TransactionList) GetTargets() []string {
+	targets := make([]string, 0)
+	for _, tx := range l.List {
+		targets = append(targets, tx.To)
+	}
+	return targets
+}

--- a/backend/internal/usecases/interfaces.go
+++ b/backend/internal/usecases/interfaces.go
@@ -1,0 +1,20 @@
+package usecases
+
+import (
+	"context"
+	"hashtracker/internal/entities"
+)
+
+type ETHTransactionRepository interface {
+	// GetTransactions retrieves all transactions on Ethereum main net
+	// associated to the specified address
+	GetTransactions(ctx context.Context, address string) (*entities.TransactionList, error)
+
+	// GetOutTransactions get just the outgoing transactions associated to a wallet.
+	GetOutTransactions(ctx context.Context, address string) (*entities.TransactionList, error)
+}
+
+type ScannerUseCase interface {
+	// GetTransactions all transactions on Ethereum main net associated to the specified address
+	GetTransactions(ctx context.Context, address string, level int) (*entities.TransactionList, error)
+}

--- a/backend/internal/usecases/repo/blockscout/result.go
+++ b/backend/internal/usecases/repo/blockscout/result.go
@@ -1,0 +1,74 @@
+package blockscout
+
+import "time"
+
+type TransactionResult struct {
+	Items          []*Item     `json:"items"`
+	NextPageParams *TxNextPage `json:"next_page_params"`
+}
+
+type Item struct {
+	Timestamp              time.Time     `json:"timestamp"`
+	Fee                    *Fee          `json:"fee"`
+	GasLimit               string        `json:"gas_limit"`
+	Block                  int           `json:"block"`
+	Status                 string        `json:"status"`
+	Method                 interface{}   `json:"method"`
+	Confirmations          int           `json:"confirmations"`
+	Type                   int           `json:"type"`
+	ExchangeRate           string        `json:"exchange_rate"`
+	To                     *Account      `json:"to"`
+	TxBurntFee             string        `json:"tx_burnt_fee"`
+	MaxFeePerGas           string        `json:"max_fee_per_gas"`
+	Result                 string        `json:"result"`
+	Hash                   string        `json:"hash"`
+	GasPrice               string        `json:"gas_price"`
+	PriorityFee            string        `json:"priority_fee"`
+	BaseFeePerGas          string        `json:"base_fee_per_gas"`
+	From                   *Account      `json:"from"`
+	TokenTransfers         interface{}   `json:"token_transfers"`
+	TxTypes                []string      `json:"tx_types"`
+	GasUsed                string        `json:"gas_used"`
+	CreatedContract        interface{}   `json:"created_contract"`
+	Position               int           `json:"position"`
+	Nonce                  int           `json:"nonce"`
+	HasErrorInInternalTxs  bool          `json:"has_error_in_internal_txs"`
+	Actions                []interface{} `json:"actions"`
+	DecodedInput           interface{}   `json:"decoded_input"`
+	TokenTransfersOverflow interface{}   `json:"token_transfers_overflow"`
+	RawInput               string        `json:"raw_input"`
+	Value                  string        `json:"value"`
+	MaxPriorityFeePerGas   string        `json:"max_priority_fee_per_gas"`
+	RevertReason           interface{}   `json:"revert_reason"`
+	TxTag                  interface{}   `json:"tx_tag"`
+}
+
+type Fee struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+type Account struct {
+	EnsDomainName   interface{}   `json:"ens_domain_name"`
+	Hash            string        `json:"hash"`
+	Implementations []interface{} `json:"implementations"`
+	IsContract      bool          `json:"is_contract"`
+	IsVerified      bool          `json:"is_verified"`
+	Metadata        interface{}   `json:"metadata"`
+	Name            interface{}   `json:"name"`
+	PrivateTags     []interface{} `json:"private_tags"`
+	ProxyType       interface{}   `json:"proxy_type"`
+	PublicTags      []interface{} `json:"public_tags"`
+	WatchlistNames  []interface{} `json:"watchlist_names"`
+}
+
+type TxNextPage struct {
+	BlockNumber int       `json:"block_number"`
+	Fee         string    `json:"fee"`
+	Hash        string    `json:"hash"`
+	Index       int       `json:"index"`
+	InsertedAt  time.Time `json:"inserted_at"`
+	ItemsCount  int       `json:"items_count"`
+	Limit       string    `json:"limit"`
+	Value       string    `json:"value"`
+}

--- a/backend/internal/usecases/repo/blockscout/transaction.go
+++ b/backend/internal/usecases/repo/blockscout/transaction.go
@@ -1,0 +1,84 @@
+package blockscout
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"hashtracker/internal/entities"
+	"hashtracker/internal/usecases"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+const (
+	baseURL = "https://eth.blockscout.com/api/v2"
+)
+
+type transaction struct {
+}
+
+func NewTransactionRepository() usecases.ETHTransactionRepository {
+	return &transaction{}
+}
+
+func (t *transaction) GetTransactions(ctx context.Context, address string) (*entities.TransactionList, error) {
+	endpoint := fmt.Sprintf("/addresses/%s/transactions", address)
+	params := url.Values{}
+	params.Add("sort", "desc")
+	// params.Add("filter", "to") // Change to "from" for outgoing transactions
+	params.Add("limit", "100") // Adjust this value as needed
+	fullURL := fmt.Sprintf("%s%s?%s", baseURL, endpoint, params.Encode())
+
+	resp, err := http.Get(fullURL)
+	if err != nil {
+		return nil, fmt.Errorf("error making request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response body: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API request failed with status code %d: %s", resp.StatusCode, string(body))
+	}
+
+	fmt.Println(string(body))
+	var result TransactionResult
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing JSON response: %v", err)
+	}
+
+	var txs []*entities.Transaction
+	for _, r := range result.Items {
+		tx := &entities.Transaction{
+			Hash:      r.Hash,
+			Value:     r.Value,
+			From:      r.From.Hash,
+			To:        r.To.Hash,
+			Timestamp: r.Timestamp,
+		}
+		fmt.Println(tx)
+		txs = append(txs, tx)
+	}
+	return entities.NewTransactionList(txs), nil
+}
+
+func (t *transaction) GetOutTransactions(ctx context.Context, address string) (*entities.TransactionList, error) {
+	txs, err := t.GetTransactions(ctx, address)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]*entities.Transaction, 0)
+	for _, tx := range txs.List {
+		if tx.To == address {
+			continue
+		}
+		results = append(results, tx)
+	}
+	return entities.NewTransactionList(results), nil
+}

--- a/backend/internal/usecases/scanner.go
+++ b/backend/internal/usecases/scanner.go
@@ -1,0 +1,26 @@
+package usecases
+
+import (
+	"context"
+	"fmt"
+	"hashtracker/internal/entities"
+)
+
+type scanner struct {
+	repo ETHTransactionRepository
+}
+
+func NewScanner(repo ETHTransactionRepository) ScannerUseCase {
+	return &scanner{
+		repo: repo,
+	}
+}
+
+func (s *scanner) GetTransactions(ctx context.Context, address string, level int) (*entities.TransactionList, error) {
+	fmt.Println("----> GetTransactions: ", address)
+	transactions, getErr := s.repo.GetTransactions(ctx, address)
+	if getErr != nil {
+		return nil, getErr
+	}
+	return transactions, nil
+}


### PR DESCRIPTION
# Description

The following PR allows us to get the Ethereum mainnet transactions associated with an address from Blockscout.